### PR TITLE
Make sure mode symbol is a function in minions--modes

### DIFF
--- a/minions.el
+++ b/minions.el
@@ -195,6 +195,7 @@ Otherwise the entry can only be used to toggle the mode."
     (dolist (mode (cl-set-difference
                    (cl-union (cl-mapcan (pcase-lambda (`(,mode ,_))
                                           (and (boundp mode)
+                                               (fboundp mode)
                                                (symbol-value mode)
                                                (list mode)))
                                         minor-mode-alist)


### PR DESCRIPTION
This is assumed later on in minions--documentation.

For a case that causes a problem, semantic-minor-modes-format was in my
minor-mode-alist and this is not a function.