### PR TITLE
Add "dash" as required package

### DIFF
--- a/minions.el
+++ b/minions.el
@@ -5,7 +5,7 @@
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/tarsius/minions
 
-;; Package-Requires: ((emacs "25.3"))
+;; Package-Requires: ((emacs "25.3") (dash "2.13.0"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -40,6 +40,7 @@
 
 (require 'cl-lib)
 (require 'subr-x)
+(require 'dash)
 
 ;;; Options
 


### PR DESCRIPTION
This PR adds `dash` as a dependency due the the `--filter` function being used here https://github.com/tarsius/minions/blob/master/minions.el#L138

I'm not sure if `2.13.0` should be the required version of dash, it's the latest one.

Thanks for this package!