### PR TITLE
Issue #13 - Fix for reloading minions

### DIFF
--- a/minions.el
+++ b/minions.el
@@ -107,8 +107,9 @@ minor-modes that is usually displayed directly in the mode line."
                               (default-value 'mode-line-format)
                               :test #'equal)))
         (if (eq banana (default-value 'mode-line-format))
-            (progn (setq minions-mode nil)
-                   (error "Cannot turn on Minions mode"))
+            (unless minions-mode
+              (progn (setq minions-mode nil)
+                     (error "Cannot turn on Minions mode")))
           (setq-default mode-line-format banana)))
     (cl-nsubst 'mode-line-modes
                'minions-mode-line-modes


### PR DESCRIPTION
Added an (unless minions-mode ...) form to check to see if minions is already loaded before throwing an error when checking if the mode-line-format is still the same when the minions-mode function is reloaded.

Without this, reloading minions when it is already loaded will cause the error to be thrown even if the setup hasn't changed.