### PR TITLE
Support emacs 25.2

### DIFF
--- a/minions.el
+++ b/minions.el
@@ -5,7 +5,7 @@
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/tarsius/minions
 
-;; Package-Requires: ((emacs "25.3") (dash "2.13.0"))
+;; Package-Requires: ((emacs "25.2") (dash "2.13.0"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Works for me on debian testing with 25.2. This allows to use the melpa package.

Is there a particular reason for 25.3?