### PR TITLE
Require subr-x at compile time

### DIFF
--- a/minions.el
+++ b/minions.el
@@ -39,8 +39,10 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'subr-x)
 (require 'dash)
+
+(eval-when-compile
+  (require 'subr-x))
 
 ;;; Options
 


### PR DESCRIPTION
The byte compiler can expand the macros at compile time meaning we do
not have to require subr-x at run time.