### PR TITLE
Use popup-menu instead of x-popup-menu to make it actually work

### DIFF
--- a/minions.el
+++ b/minions.el
@@ -211,7 +211,7 @@ EVENT has to be an input event."
           (define-key map (vector mode) menu)
         (minions--define-toggle map mode)))
     (define-key map [--local] (list 'menu-item "Local Modes"))
-    (x-popup-menu event map)))
+    (popup-menu map event)))
 
 (defun minions--modes ()
   (let (local global)


### PR DESCRIPTION
Currently, the menu does not really do anything when an item is chosen
because x-popup-menu only returns the list of events but does not
execute the corresponding command.  From the documentation:

    When MENU is a keymap or a list of keymaps, the return value is
    the list of events corresponding to the user's choice.  Note that
    x-popup-menu does not actually execute the command bound to that
    sequence of events.

We should therefore use popup-menu instead to fix things.