### PR TITLE
Applying minions-mode-line-face to major-mode indicator

### DIFF
--- a/minions.el
+++ b/minions.el
@@ -148,13 +148,14 @@ minor-modes that is usually displayed directly in the mode line."
   (let ((recursive-edit-help-echo "Recursive edit, type C-M-c to get out"))
     (list (propertize "%[" 'help-echo recursive-edit-help-echo)
           '(:eval (car minions-mode-line-delimiters))
-          `(:propertize ("" mode-name)
-                        help-echo "Major mode
+          '(:eval (propertize mode-name
+                              'help-echo "Major mode
 mouse-1: Display major mode menu
 mouse-2: Show help for major mode
 mouse-3: Toggle minor modes"
-                        mouse-face mode-line-highlight
-                        local-map ,mode-line-major-mode-keymap)
+                              'face minions-mode-line-face
+                              'mouse-face 'mode-line-highlight
+                              'local-map mode-line-major-mode-keymap))
           '("" mode-line-process)
           (propertize "%n" 'help-echo "mouse-2: Remove narrowing from buffer"
                       'mouse-face 'mode-line-highlight


### PR DESCRIPTION
Hello!

I've been using `minions` with the vanilla mode-line and everything was ok. `minions` is fantastic!

Now I've moved from vanilla mode-line to the `telephone-line`. As the built in minions segment doesn't support mouse clicks (it just prints plain text) I've injected `minions` into it. But I found that the major-mode part of the result doesn't use the background provided but inherits the base mode-line face:

![telephon-line-pre](https://user-images.githubusercontent.com/29946047/151306578-aec5cb6b-04f5-48bc-bed7-c58a4b12c782.png)

I've tried to propertize major-mode part with the same code as for minor-mode part and it seems to work!

![telephon-line-post](https://user-images.githubusercontent.com/29946047/151306747-cf3c7d1f-f211-4763-a6fc-56a1fb82b013.png)
![telephon-line-post2](https://user-images.githubusercontent.com/29946047/151306779-5e7c976a-e277-4f74-8347-ce144d274c9c.png)

This changes keep `minions` working for the vanilla mode-line both standard and themed:
![vanilla](https://user-images.githubusercontent.com/29946047/151306952-7df4989c-1407-4a65-866a-7fb63a7acbd4.png)
![doom](https://user-images.githubusercontent.com/29946047/151306958-73052b82-d6aa-4d8a-a07b-2d5b1d08bf33.png)

