### PR TITLE
Expect the lighter to include a leading space

### DIFF
--- a/minions.el
+++ b/minions.el
@@ -102,7 +102,7 @@ global minor-mode, nil otherwise."
   :group 'mode-line-faces
   :type '(choice (const :tag "No face" nil) face))
 
-(defcustom minions-mode-line-lighter ";-"
+(defcustom minions-mode-line-lighter " ;-"
   "Text used for the mode menu in the mode line."
   :package-version '(minions . "0.2.0")
   :group 'minions
@@ -166,7 +166,6 @@ mouse-1: Display minor mode menu
 mouse-2: Show help for minor mode
 mouse-3: Toggle minor modes"
                         local-map ,mode-line-minor-mode-keymap)
-          " "
           '(:eval (propertize minions-mode-line-lighter
                               'face minions-mode-line-face
                               'mouse-face 'mode-line-highlight


### PR DESCRIPTION
Currently, the variable `minions-mode-line-modes` includes a space to separate the lighter from the list of prominent modes. When `minions-mode-line-lighter` is set to be empty, the separating space remains (though usually invisible). It becomes visible, for instance, upon entering recursive edit: instead of `[ELisp/l]` we see `[ELisp/l ]` at the rightmost end of the mode line. 

I made a small change to fix this by removing the space from `minions-mode-line-modes` and expecting the lighter to include a leading space. This avoids the above issue without affecting the default behavior.